### PR TITLE
fix(assets): add spans to glyphs

### DIFF
--- a/src/assets/data/edition/series/1/section/5/op12/textcritics.json
+++ b/src/assets/data/edition/series/1/section/5/op12/textcritics.json
@@ -15,7 +15,7 @@
                             "measure": "1",
                             "system": "Klav. o.",
                             "position": "2/4",
-                            "comment": "{{ref.getGlyph('[#]')}} zu gis<sup>1</sup> ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu gis<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -50,14 +50,14 @@
                             "measure": "13",
                             "system": "Ges.",
                             "position": "2/8",
-                            "comment": "{{ref.getGlyph('[pp]')}} <em>äußerst ruhig</em> in eine Zeile gesetzt gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_F'})\"><strong>F</strong></a>. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: <em>äußerst ruhig</em> | {{ref.getGlyph('[pp]')}}."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[pp]')}}</span> <em>äußerst ruhig</em> in eine Zeile gesetzt gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_F'})\"><strong>F</strong></a>. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: <em>äußerst ruhig</em> | <span class='glyph'>{{ref.getGlyph('[pp]')}}</span>."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "13",
                             "system": "Klav. u.",
                             "position": "3/4",
-                            "comment": "{{ref.getGlyph('[pp]')}} unter das System versetzt mit Blick auf den weiteren dynamischen Verlauf."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[pp]')}}</span> unter das System versetzt mit Blick auf den weiteren dynamischen Verlauf."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -83,14 +83,14 @@
                             "measure": "4",
                             "system": "Klav. u.",
                             "position": "6. Note",
-                            "comment": "{{ref.getGlyph('[ppp]')}} von zwischen den Klav.-Systemen versetzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[ppp]')}}</span> von zwischen den Klav.-Systemen versetzt."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "7",
                             "system": "Klav.",
                             "position": "1/8",
-                            "comment": "{{ref.getGlyph('[#]')}} zu fis und cis<sup>2</sup> als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: Akkoladenwechsel nach T. 6."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu fis und cis<sup>2</sup> als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: Akkoladenwechsel nach T. 6."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -104,14 +104,14 @@
                             "measure": "10",
                             "system": "Klav. u.",
                             "position": "1/4",
-                            "comment": "{{ref.getGlyph('[b]')}} zu B als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: Akkoladenwechsel nach T. 9."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu B als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: Akkoladenwechsel nach T. 9."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "12",
                             "system": "Klav. u.",
                             "position": "1. Note",
-                            "comment": "{{ref.getGlyph('[b]')}} zu Es/as ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: kein Akkoladenwechsel nach T. 11."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu Es/as ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: kein Akkoladenwechsel nach T. 11."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -153,14 +153,14 @@
                             "measure": "23",
                             "system": "Klav. u.",
                             "position": "1/4",
-                            "comment": "{{ref.getGlyph('[a]')}} zu a als redundant weggelassen."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu a als redundant weggelassen."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "25",
                             "system": "Klav. o.",
                             "position": "1/4",
-                            "comment": "{{ref.getGlyph('[b]')}} zu b, {{ref.getGlyph('[a]')}} zu a<sup>1</sup> als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: Akkoladenwechsel nach T. 24."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu b, <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu a<sup>1</sup> als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: Akkoladenwechsel nach T. 24."
                         }
                     ]
                 },
@@ -214,7 +214,7 @@
                             "measure": "13",
                             "system": "Klav. o.",
                             "position": "1. Note",
-                            "comment": "{{ref.getGlyph('[#]')}} zu cis<sup>1</sup> und {{ref.getGlyph('[a]')}} zu c<sup>2</sup> nach Akkoladenwechsel ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: kein Akkoladenwechsel nach T. 12."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu cis<sup>1</sup> und <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu c<sup>2</sup> nach Akkoladenwechsel ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: kein Akkoladenwechsel nach T. 12."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -235,7 +235,7 @@
                             "measure": "17",
                             "system": "Klav. o.",
                             "position": "",
-                            "comment": "{{ref.getGlyph('[a]')}} zu g als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_F'})\"><strong>F</strong></a>: Akzidenzien zu es/g/cis<sup>1</sup> fehlen nach Akkoladenwechsel. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: Akzidenzien zu es/g/cis<sup>1</sup> nach Akkoladenwechsel."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu g als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_F'})\"><strong>F</strong></a>: Akzidenzien zu es/g/cis<sup>1</sup> fehlen nach Akkoladenwechsel. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: Akzidenzien zu es/g/cis<sup>1</sup> nach Akkoladenwechsel."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -270,7 +270,7 @@
                             "measure": "27",
                             "system": "Klav. o.",
                             "position": "1/16",
-                            "comment": "{{ref.getGlyph('[#]')}} zu cis<sup>2</sup> als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: Akkoladenwechsel nach T. 26."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu cis<sup>2</sup> als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: Akkoladenwechsel nach T. 26."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -291,7 +291,7 @@
                             "measure": "35",
                             "system": "",
                             "position": "Taktanfang",
-                            "comment": "Zeilenfall bei <em>sehr ruhig | (</em>{{ref.getGlyph('[Achtelnote]')}} <em>= ca 100)</em>. aufgelöst gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_F'})\"><strong>F</strong></a>. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: Auf Grund des Akkoladenwechsels nach T. 35 nicht ausreichend Raum bis zum Seitenrand für die Tempobezeichnung in einer Zeile."
+                            "comment": "Zeilenfall bei <em>sehr ruhig | (</em><span class='glyph'>{{ref.getGlyph('[Achtelnote]')}}</span> <em>= ca 100)</em>. aufgelöst gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_F'})\"><strong>F</strong></a>. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: Auf Grund des Akkoladenwechsels nach T. 35 nicht ausreichend Raum bis zum Seitenrand für die Tempobezeichnung in einer Zeile."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -305,7 +305,7 @@
                             "measure": "36",
                             "system": "Klav. u.",
                             "position": "1. Note",
-                            "comment": "{{ref.getGlyph('[b]')}} zu ges als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: Akkoladenwechsel nach T. 35."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu ges als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: Akkoladenwechsel nach T. 35."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -319,14 +319,14 @@
                             "measure": "38",
                             "system": "Klav. o.",
                             "position": "1. Note",
-                            "comment": "{{ref.getGlyph('[#]')}} zu dis<sup>1</sup> und {{ref.getGlyph('[a]')}} zu g<sup>1</sup> nach Akkoladenwechsel ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: kein Akkoladenwechsel."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu dis<sup>1</sup> und <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu g<sup>1</sup> nach Akkoladenwechsel ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: kein Akkoladenwechsel."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "38",
                             "system": "Klav. u.",
                             "position": "",
-                            "comment": "{{ref.getGlyph('[#]')}} zu Gis nach Akkoladenwechsel ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: kein Akkoladenwechsel."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu Gis nach Akkoladenwechsel ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: kein Akkoladenwechsel."
                         }
                     ]
                 },
@@ -352,7 +352,7 @@
                             "measure": "16",
                             "system": "Klav. o.",
                             "position": "1. Note",
-                            "comment": "Unterstimmenschicht: {{ref.getGlyph('[b]')}} zu es ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: kein Akkoladenwechsel nach T. 15."
+                            "comment": "Unterstimmenschicht: <span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu es ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: kein Akkoladenwechsel nach T. 15."
                         },
                         {
                             "svgGroupId": "TODO",

--- a/src/assets/data/edition/series/1/section/5/op23/textcritics.json
+++ b/src/assets/data/edition/series/1/section/5/op23/textcritics.json
@@ -22,7 +22,7 @@
                             "measure": "6",
                             "system": "Ges.",
                             "position": "1/8",
-                            "comment": "{{ref.getGlyph('[#]')}} zu gis<sup>1</sup> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op23', fragmentId: 'source_D'})\"><strong>D</strong></a>: kein Akkoladenwechsel nach T. 5."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu gis<sup>1</sup> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op23', fragmentId: 'source_D'})\"><strong>D</strong></a>: kein Akkoladenwechsel nach T. 5."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -99,14 +99,14 @@
                             "measure": "20",
                             "system": "Klav. o.",
                             "position": "1. Note",
-                            "comment": "{{ref.getGlyph('[pp]')}} ergänzt gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op23', fragmentId: 'source_C'})\"><strong>C</strong></a>."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[pp]')}}</span> ergänzt gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op23', fragmentId: 'source_C'})\"><strong>C</strong></a>."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "22",
                             "system": "Ges.",
                             "position": "1. Note",
-                            "comment": "{{ref.getGlyph('[a]')}} zu g<sup>2</sup> ergänzt gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op23', fragmentId: 'source_C'})\"><strong>C</strong></a>."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu g<sup>2</sup> ergänzt gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op23', fragmentId: 'source_C'})\"><strong>C</strong></a>."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -230,7 +230,7 @@
                             "measure": "14",
                             "system": "Ges.",
                             "position": "1/8",
-                            "comment": "{{ref.getGlyph('[b]')}} zu b<sup>2</sup> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op23', fragmentId: 'source_D'})\"><strong>D</strong></a>: kein Akkoladenwechsel nach T. 13."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu b<sup>2</sup> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op23', fragmentId: 'source_D'})\"><strong>D</strong></a>: kein Akkoladenwechsel nach T. 13."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -279,7 +279,7 @@
                             "measure": "23",
                             "system": "Klav. u.",
                             "position": "1/8",
-                            "comment": "{{ref.getGlyph('[#]')}} als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op23', fragmentId: 'source_D'})\"><strong>D</strong></a>: Akkoladenwechsel nach T. 22."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[#]')}}</span> als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op23', fragmentId: 'source_D'})\"><strong>D</strong></a>: Akkoladenwechsel nach T. 22."
                         },
                         {
                             "svgGroupId": "TODO",

--- a/src/assets/data/edition/series/1/section/5/op25/textcritics.json
+++ b/src/assets/data/edition/series/1/section/5/op25/textcritics.json
@@ -22,14 +22,14 @@
                             "measure": "3",
                             "system": "Ges.",
                             "position": "1. Note",
-                            "comment": "{{ref.getGlyph('[f]')}} versetzt von 1. Pause. <br /> Text sic: Kleinschreibung <em>noch</em> (wie <a (click)=\"ref.navigateToReportFragment({complexId: 'op25', fragmentId: 'text_Jone_DF'})\"><strong>Jone_DF</strong></a>)."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[f]')}}</span> versetzt von 1. Pause. <br /> Text sic: Kleinschreibung <em>noch</em> (wie <a (click)=\"ref.navigateToReportFragment({complexId: 'op25', fragmentId: 'text_Jone_DF'})\"><strong>Jone_DF</strong></a>)."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "4",
                             "system": "Ges.",
                             "position": "8/8",
-                            "comment": "{{ref.getGlyph('[p]')}} versetzt von 7/8."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[p]')}}</span> versetzt von 7/8."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -64,7 +64,7 @@
                             "measure": "7",
                             "system": "Klav. u.",
                             "position": "4/8",
-                            "comment": "{{ref.getGlyph('[sf]')}} versetzt von innerhalb des Systems."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[sf]')}}</span> versetzt von innerhalb des Systems."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -78,7 +78,7 @@
                             "measure": "8",
                             "system": "Ges.",
                             "position": "5. Note",
-                            "comment": "{{ref.getGlyph('[f]')}} versetzt von 2. Pause. <br /> Text sic: Kleinschreibung <em>noch</em> (wie <a (click)=\"ref.navigateToReportFragment({complexId: 'op25', fragmentId: 'text_Jone_DF'})\"><strong>Jone_DF</strong></a>)."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[f]')}}</span> versetzt von 2. Pause. <br /> Text sic: Kleinschreibung <em>noch</em> (wie <a (click)=\"ref.navigateToReportFragment({complexId: 'op25', fragmentId: 'text_Jone_DF'})\"><strong>Jone_DF</strong></a>)."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -118,7 +118,7 @@
                             "measure": "3",
                             "system": "Ges.",
                             "position": "6/16",
-                            "comment": "{{ref.getGlyph('[p]')}} versetzt von 5/16."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[p]')}}</span> versetzt von 5/16."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -132,21 +132,21 @@
                             "measure": "29",
                             "system": "Ges.",
                             "position": "2/16",
-                            "comment": "{{ref.getGlyph('[f]')}} versetzt von 1/16."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[f]')}}</span> versetzt von 1/16."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "30",
                             "system": "Ges.",
                             "position": "6/16",
-                            "comment": "{{ref.getGlyph('[p]')}} versetzt von 5/16."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[p]')}}</span> versetzt von 5/16."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "32",
                             "system": "Ges.",
                             "position": "6/16",
-                            "comment": "{{ref.getGlyph('[p]')}} versetzt von 5/16."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[p]')}}</span> versetzt von 5/16."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -167,7 +167,7 @@
                             "measure": "33",
                             "system": "Klav. u.",
                             "position": "2/16",
-                            "comment": "{{ref.getGlyph('[p]')}} versetzt von 1/16."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[p]')}}</span> versetzt von 1/16."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -181,7 +181,7 @@
                             "measure": "36",
                             "system": "Ges.",
                             "position": "1/16",
-                            "comment": "{{ref.getGlyph('[#]')}} zu gis<sup>1</sup> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op25', fragmentId: 'source_E'})\"><strong>E</strong></a>: kein Akkoladenwechsel nach T. 35."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu gis<sup>1</sup> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op25', fragmentId: 'source_E'})\"><strong>E</strong></a>: kein Akkoladenwechsel nach T. 35."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -249,7 +249,7 @@
                             "measure": "31",
                             "system": "",
                             "position": "2/4",
-                            "comment": "Eckige Klammern um {{ref.getGlyph('[Halbe Note]')}} <em>= ca 96</em> geändert zu runden Klammern."
+                            "comment": "Eckige Klammern um <span class='glyph'>{{ref.getGlyph('[Halbe Note]')}}</span> <em>= ca 96</em> geändert zu runden Klammern."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -291,7 +291,7 @@
                             "measure": "57",
                             "system": "Ges.",
                             "position": "1/4",
-                            "comment": "{{ref.getGlyph('[b]')}} zu b<sup>1</sup> ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu b<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -319,7 +319,7 @@
                             "measure": "76",
                             "system": "",
                             "position": "2/4",
-                            "comment": "Punkt nach <em>tempo I</em> weggelassen, eckige Klammern um {{ref.getGlyph('[Halbe Note]')}} <em>= ca 96</em> geändert zu runden Klammern."
+                            "comment": "Punkt nach <em>tempo I</em> weggelassen, eckige Klammern um <span class='glyph'>{{ref.getGlyph('[Halbe Note]')}}</span> <em>= ca 96</em> geändert zu runden Klammern."
                         },
                         {
                             "svgGroupId": "TODO",

--- a/src/assets/data/edition/series/1/section/5/op3/textcritics.json
+++ b/src/assets/data/edition/series/1/section/5/op3/textcritics.json
@@ -57,7 +57,7 @@
                             "measure": "3",
                             "system": "Klav. o.",
                             "position": "4/8",
-                            "comment": "{{ref.getGlyph('[a]')}} zu f<sup>2</sup> ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu f<sup>2</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -71,7 +71,7 @@
                             "measure": "4",
                             "system": "Klav. o.",
                             "position": "4. Note",
-                            "comment": "{{ref.getGlyph('[a]')}} zu f<sup>2</sup> ergänzt.  <br /> Ende der Crescendogabel und Anfang der Decrescendogabel versetzt von zwischen 4. und 5. Note mit Blick auf Textfassung 3."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu f<sup>2</sup> ergänzt.  <br /> Ende der Crescendogabel und Anfang der Decrescendogabel versetzt von zwischen 4. und 5. Note mit Blick auf Textfassung 3."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -85,7 +85,7 @@
                             "measure": "4",
                             "system": "Klav. u.",
                             "position": "6/8",
-                            "comment": "{{ref.getGlyph('[a]')}} zu d ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu d ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -113,7 +113,7 @@
                             "measure": "6",
                             "system": "Klav. u.",
                             "position": "11/16",
-                            "comment": "{{ref.getGlyph('[a]')}} zu d ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu d ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -127,7 +127,7 @@
                             "measure": "7",
                             "system": "Klav. o.",
                             "position": "11/16",
-                            "comment": "{{ref.getGlyph('[ppp]')}} versetzt von Höhe 10/16."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[ppp]')}}</span> versetzt von Höhe 10/16."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -216,7 +216,7 @@
                             "measure": "2",
                             "system": "Klav. o.",
                             "position": "1/16",
-                            "comment": "Unterstimmenschicht: {{ref.getGlyph('[a]')}} zu f<sup>1</sup>/d<sup>2</sup> als redundant weggelassen."
+                            "comment": "Unterstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu f<sup>1</sup>/d<sup>2</sup> als redundant weggelassen."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -312,7 +312,7 @@
                             "measure": "3",
                             "system": "Klav. o.",
                             "position": "4/16",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[a]')}} zu g<sup>1</sup> ergänzt."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu g<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -333,7 +333,7 @@
                             "measure": "7",
                             "system": "Klav. u.",
                             "position": "1. Note",
-                            "comment": "Unterstimmenschicht: {{ref.getGlyph('[a]')}} zu d ergänzt."
+                            "comment": "Unterstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu d ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -354,7 +354,7 @@
                             "measure": "8",
                             "system": "Klav. u.",
                             "position": "2. Note",
-                            "comment": "Unterstimmenschicht: {{ref.getGlyph('[a]')}} zu d ergänzt."
+                            "comment": "Unterstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu d ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -382,7 +382,7 @@
                             "measure": "8",
                             "system": "Klav. u.",
                             "position": "3. Note",
-                            "comment": "{{ref.getGlyph('[a]')}} zu e ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu e ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -403,21 +403,21 @@
                             "measure": "9",
                             "system": "Klav. u.",
                             "position": "1. Note",
-                            "comment": "{{ref.getGlyph('[a]')}} zu d ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu d ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "9",
                             "system": "Klav. o.",
                             "position": "2. Note",
-                            "comment": "Unterstimmenschicht: {{ref.getGlyph('[a]')}} zu f<sup>1</sup> ergänzt."
+                            "comment": "Unterstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu f<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "10",
                             "system": "Klav. o.",
                             "position": "1. Note",
-                            "comment": "Unterstimmenschicht: Ende des Legatobogens versetzt von T. 9 letzte Note.  <br /> <a (click)=\"ref.navigateToReportFragment({complexId: 'op3', fragmentId: 'source_L'})\"><strong>L</strong></a>/<a (click)=\"ref.navigateToReportFragment({complexId: 'op3', fragmentId: 'source_M'})\"><strong>M</strong></a>: kein Akkoladenwechsel nach T. 9, trotzdem {{ref.getGlyph('[b]')}} zu es<sup>1</sup>."
+                            "comment": "Unterstimmenschicht: Ende des Legatobogens versetzt von T. 9 letzte Note.  <br /> <a (click)=\"ref.navigateToReportFragment({complexId: 'op3', fragmentId: 'source_L'})\"><strong>L</strong></a>/<a (click)=\"ref.navigateToReportFragment({complexId: 'op3', fragmentId: 'source_M'})\"><strong>M</strong></a>: kein Akkoladenwechsel nach T. 9, trotzdem <span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu es<sup>1</sup>."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -450,7 +450,7 @@
                             "measure": "1",
                             "system": "Klav. u.",
                             "position": "4/8",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[a]')}} zu e ergänzt."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu e ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -471,21 +471,21 @@
                             "measure": "2",
                             "system": "Klav. o.",
                             "position": "7. Note",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[a]')}} zu f<sup>1</sup> ergänzt."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu f<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "4",
                             "system": "Klav. o.",
                             "position": "1/16",
-                            "comment": "Unterstimmenschicht: {{ref.getGlyph('[b]')}} zu as<sup>1</sup> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op3', fragmentId: 'source_L'})\"><strong>L</strong></a>/<a (click)=\"ref.navigateToReportFragment({complexId: 'op3', fragmentId: 'source_M'})\"><strong>M</strong></a>: kein Akkoladenwechsel nach T. 3."
+                            "comment": "Unterstimmenschicht: <span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu as<sup>1</sup> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op3', fragmentId: 'source_L'})\"><strong>L</strong></a>/<a (click)=\"ref.navigateToReportFragment({complexId: 'op3', fragmentId: 'source_M'})\"><strong>M</strong></a>: kein Akkoladenwechsel nach T. 3."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "4",
                             "system": "Klav. u.",
                             "position": "7/16",
-                            "comment": "{{ref.getGlyph('[a]')}} zu D ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu D ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -499,7 +499,7 @@
                             "measure": "6",
                             "system": "Ges.",
                             "position": "1/4",
-                            "comment": "{{ref.getGlyph('[a]')}} zu g<sup>1</sup> ergänzt. <br /> Text sic: drei Punkte nach <em>Staub</em>. <a (click)=\"ref.navigateToReportFragment({complexId: 'op3', fragmentId: 'text_George_DsR'})\"><strong>George_DsR</strong></a>: zwei Punkte."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu g<sup>1</sup> ergänzt. <br /> Text sic: drei Punkte nach <em>Staub</em>. <a (click)=\"ref.navigateToReportFragment({complexId: 'op3', fragmentId: 'text_George_DsR'})\"><strong>George_DsR</strong></a>: zwei Punkte."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -581,7 +581,7 @@
                             "measure": "5",
                             "system": "Klav. u.",
                             "position": "6/8",
-                            "comment": "Unterstimmenschicht: {{ref.getGlyph('[a]')}} zu a ergänzt."
+                            "comment": "Unterstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu a ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -595,14 +595,14 @@
                             "measure": "7",
                             "system": "Klav. u.",
                             "position": "4/8",
-                            "comment": "Unterstimmenschicht: {{ref.getGlyph('[a]')}} zu f ergänzt."
+                            "comment": "Unterstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu f ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "7",
                             "system": "Klav. u.",
                             "position": "5/8",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[a]')}} zu c<sup>1</sup>, {{ref.getGlyph('[b]')}} zu es<sup>1</sup> ergänzt."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu c<sup>1</sup>, <span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu es<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -630,14 +630,14 @@
                             "measure": "10",
                             "system": "Klav. o.",
                             "position": "1/8",
-                            "comment": "Ende des Legatobogens versetzt von T. 9 6/8. <br /> {{ref.getGlyph('[#]')}} zu gis<sup>1</sup> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op3', fragmentId: 'source_L'})\"><strong>L</strong></a>/<a (click)=\"ref.navigateToReportFragment({complexId: 'op3', fragmentId: 'source_M'})\"><strong>M</strong></a>: kein Akkoladenwechsel nach T. 9."
+                            "comment": "Ende des Legatobogens versetzt von T. 9 6/8. <br /> <span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu gis<sup>1</sup> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op3', fragmentId: 'source_L'})\"><strong>L</strong></a>/<a (click)=\"ref.navigateToReportFragment({complexId: 'op3', fragmentId: 'source_M'})\"><strong>M</strong></a>: kein Akkoladenwechsel nach T. 9."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "10",
                             "system": "Klav. o.",
                             "position": "1. Note",
-                            "comment": "Viertelnote {{ref.getGlyph('[a]')}}a korrigiert zu punktierter Viertelnote mit Blick auf den metrischen Kontext sowie auf Textfassung 3 und Textfassung 4."
+                            "comment": "Viertelnote <span class='glyph'>{{ref.getGlyph('[a]')}}</span>a korrigiert zu punktierter Viertelnote mit Blick auf den metrischen Kontext sowie auf Textfassung 3 und Textfassung 4."
                         },
                         {
                             "svgGroupId": "TODO",

--- a/src/assets/data/edition/series/1/section/5/op4/textcritics.json
+++ b/src/assets/data/edition/series/1/section/5/op4/textcritics.json
@@ -43,14 +43,14 @@
                             "measure": "2",
                             "system": "Ges.",
                             "position": "2. Note",
-                            "comment": "{{ref.getGlyph('[pp]')}} ergänzt gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_I'})\"><strong>I</strong></a>."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[pp]')}}</span> ergänzt gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_I'})\"><strong>I</strong></a>."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "3",
                             "system": "Klav. o.",
                             "position": "3. Note",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[a]')}} zu e<sup>1</sup> ergänzt."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu e<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -64,28 +64,28 @@
                             "measure": "4",
                             "system": "Klav. o.",
                             "position": "3/4",
-                            "comment": "{{ref.getGlyph('[a]')}} zu e<sup>1</sup>, {{ref.getGlyph('[b]')}} zu b<sup>1</sup>/es<sup>2</sup> ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu e<sup>1</sup>, <span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu b<sup>1</sup>/es<sup>2</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "4",
                             "system": "Klav. u.",
                             "position": "3/4",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[a]')}} zu f, {{ref.getGlyph('[#]')}} zu cis<sup>1</sup> ergänzt."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu f, <span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu cis<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "4",
                             "system": "Klav. o.",
                             "position": "7/4",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[b]')}} zu es<sup>2</sup> ergänzt gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_I'})\"><strong>I</strong></a> ante correcturam.  <br /> Unterstimmenschicht: {{ref.getGlyph('[a]')}} zu e<sup>1</sup>, {{ref.getGlyph('[b]')}} zu b<sup>1</sup> ergänzt."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu es<sup>2</sup> ergänzt gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_I'})\"><strong>I</strong></a> ante correcturam.  <br /> Unterstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu e<sup>1</sup>, <span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu b<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "4",
                             "system": "Klav. u.",
                             "position": "7/4",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[a]')}} zu f, {{ref.getGlyph('[#]')}} zu cis<sup>1</sup> ergänzt."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu f, <span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu cis<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -141,14 +141,14 @@
                             "measure": "6",
                             "system": "Klav. o.",
                             "position": "1/2",
-                            "comment": "Unterstimmenschicht: {{ref.getGlyph('[a]')}} zu d<sup>3</sup> als redundant weggelassen."
+                            "comment": "Unterstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu d<sup>3</sup> als redundant weggelassen."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "6",
                             "system": "Klav. u.",
                             "position": "1/8",
-                            "comment": "Oberstimmenschicht: Ende des Legatobogens versetzt von T. 5 letzte Note.  <br /> {{ref.getGlyph('[a]')}} zu g als redundant weggelassen."
+                            "comment": "Oberstimmenschicht: Ende des Legatobogens versetzt von T. 5 letzte Note.  <br /> <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu g als redundant weggelassen."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -162,7 +162,7 @@
                             "measure": "6",
                             "system": "Klav. o.",
                             "position": "22/16",
-                            "comment": "{{ref.getGlyph('[a]')}} zu h<sup>1</sup>, {{ref.getGlyph('[#]')}} zu gis<sup>2</sup> ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu h<sup>1</sup>, <span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu gis<sup>2</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -190,7 +190,7 @@
                             "measure": "8",
                             "system": "Ges.",
                             "position": "12. Note",
-                            "comment": "{{ref.getGlyph('[a]')}} als redundant weggelassen."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> als redundant weggelassen."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -218,7 +218,7 @@
                             "measure": "9",
                             "system": "Ges.",
                             "position": "6. Note",
-                            "comment": "{{ref.getGlyph('[a]')}} zu g<sup>1</sup> ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu g<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -253,21 +253,21 @@
                             "measure": "10",
                             "system": "Klav. u.",
                             "position": "1/8",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[a]')}} zu f als redundant weggelassen."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu f als redundant weggelassen."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "10",
                             "system": "Klav. o.",
                             "position": "2/8",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[b]')}} zu es<sup>2</sup> ergänzt.  <br /> Unterstimmenschicht: {{ref.getGlyph('[a]')}} zu e<sup>1</sup>, {{ref.getGlyph('[b]')}} zu b<sup>1</sup> ergänzt."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu es<sup>2</sup> ergänzt.  <br /> Unterstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu e<sup>1</sup>, <span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu b<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "10",
                             "system": "Klav. u.",
                             "position": "2/8",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[a]')}} zu f, {{ref.getGlyph('[#]')}} zu cis<sup>1</sup> ergänzt."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu f, <span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu cis<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -323,14 +323,14 @@
                             "measure": "12",
                             "system": "Klav. o.",
                             "position": "1/4",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[a]')}} zu h<sup>2</sup>, {{ref.getGlyph('[b]')}} zu b<sup>3</sup> ergänzt.  <br /> Unterstimmenschicht: {{ref.getGlyph('[b]')}} zu es<sup>2</sup> ergänzt.  <br /> <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: kein Akkoladenwechsel nach T. 11."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu h<sup>2</sup>, <span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu b<sup>3</sup> ergänzt.  <br /> Unterstimmenschicht: <span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu es<sup>2</sup> ergänzt.  <br /> <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: kein Akkoladenwechsel nach T. 11."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "12",
                             "system": "Klav. u.",
                             "position": "1/4",
-                            "comment": "{{ref.getGlyph('[#]')}} zu Cis<sub>1</sub> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: kein Akkoladenwechsel nach T. 11."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu Cis<sub>1</sub> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: kein Akkoladenwechsel nach T. 11."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -351,21 +351,21 @@
                             "measure": "13",
                             "system": "Klav. o.",
                             "position": "5. Note",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[a]')}} zu e<sup>2</sup> ergänzt."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu e<sup>2</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "13",
                             "system": "Klav. o.",
                             "position": "letzte Note",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[a]')}} zu e<sup>1</sup> ergänzt."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu e<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "13",
                             "system": "Klav. u.",
                             "position": "2. Note",
-                            "comment": "Unterstimmenschicht: {{ref.getGlyph('[a]')}} zu F<sub>1</sub> ergänzt."
+                            "comment": "Unterstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu F<sub>1</sub> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -379,14 +379,14 @@
                             "measure": "14",
                             "system": "Klav. u.",
                             "position": "2. Note",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[a]')}} zu E/H/e ergänzt."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu E/H/e ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "14 <br /> bis 15",
                             "system": "Klav.",
                             "position": "(6/4) <br /> letzte Note",
-                            "comment": "<a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_H'})\"><strong>H</strong></a> und <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_I'})\"><strong>I</strong></a>: {{ref.getGlyph('[ppp]')}} zu T. 14 (6/4) und anschließende Decrescendogabel bis T. 15 letzte Note."
+                            "comment": "<a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_H'})\"><strong>H</strong></a> und <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_I'})\"><strong>I</strong></a>: <span class='glyph'>{{ref.getGlyph('[ppp]')}}</span> zu T. 14 (6/4) und anschließende Decrescendogabel bis T. 15 letzte Note."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -433,7 +433,7 @@
                             "measure": "3",
                             "system": "Klav. o.",
                             "position": "3. Note",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[b]')}} zu es<sup>2</sup> ergänzt."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu es<sup>2</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -461,14 +461,14 @@
                             "measure": "6",
                             "system": "Klav. o.",
                             "position": "1. Note",
-                            "comment": "{{ref.getGlyph('[a]')}} zu d<sup>1</sup> ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu d<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "6",
                             "system": "Klav. u.",
                             "position": "1. Note",
-                            "comment": "Unterstimmenschicht: {{ref.getGlyph('[a]')}} zu A als redundant weggelassen."
+                            "comment": "Unterstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu A als redundant weggelassen."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -517,7 +517,7 @@
                             "measure": "15",
                             "system": "Ges.",
                             "position": "3. Note",
-                            "comment": "{{ref.getGlyph('[mf]')}} versetzt von 4/8 gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_I'})\"><strong>I</strong></a>.  <br /> Text sic: <em>muß</em>. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'text_George_DJdS'})\"><strong>George_DJdS</strong></a>: <em>muss</em>."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[mf]')}}</span> versetzt von 4/8 gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_I'})\"><strong>I</strong></a>.  <br /> Text sic: <em>muß</em>. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'text_George_DJdS'})\"><strong>George_DJdS</strong></a>: <em>muss</em>."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -552,7 +552,7 @@
                             "measure": "20",
                             "system": "Klav. o.",
                             "position": "2/4",
-                            "comment": "{{ref.getGlyph('[ppp]')}} ergänzt gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_I'})\"><strong>I</strong></a>."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[ppp]')}}</span> ergänzt gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_I'})\"><strong>I</strong></a>."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -578,7 +578,7 @@
                             "measure": "1",
                             "system": "Klav. u.",
                             "position": "8/8",
-                            "comment": "{{ref.getGlyph('[a]')}} zu F<sub>1</sub> ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu F<sub>1</sub> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -641,7 +641,7 @@
                             "measure": "13",
                             "system": "Ges.",
                             "position": "4/16",
-                            "comment": "{{ref.getGlyph('[a]')}} zu a<sup>1</sup> ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu a<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -655,7 +655,7 @@
                             "measure": "15",
                             "system": "Klav. u.",
                             "position": "1. Note",
-                            "comment": "{{ref.getGlyph('[ppp]')}} versetzt von 2. Note gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_H'})\"><strong>H</strong></a>."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[ppp]')}}</span> versetzt von 2. Note gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_H'})\"><strong>H</strong></a>."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -695,14 +695,14 @@
                             "measure": "vor 1",
                             "system": "Klav. o.",
                             "position": "",
-                            "comment": "{{ref.getGlyph('[a]')}} zu h<sup>1</sup> ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu h<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "1",
                             "system": "Klav. o.",
                             "position": "3/8",
-                            "comment": "{{ref.getGlyph('[a]')}} zu a<sup>1</sup> ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu a<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -716,7 +716,7 @@
                             "measure": "2",
                             "system": "Klav. o.",
                             "position": "1. Note",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[a]')}} zu h<sup>1</sup> ergänzt."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu h<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -730,35 +730,35 @@
                             "measure": "4",
                             "system": "Klav. o.",
                             "position": "1/16",
-                            "comment": "{{ref.getGlyph('[b]')}} zu h<sup>1</sup> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: kein Akkoladenwechsel nach T. 3."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu h<sup>1</sup> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: kein Akkoladenwechsel nach T. 3."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "4",
                             "system": "Klav. u.",
                             "position": "1/16",
-                            "comment": "{{ref.getGlyph('[#]')}} zu Gis und {{ref.getGlyph('[a]')}} zu g ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: kein Akkoladenwechsel nach T. 3."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu Gis und <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu g ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: kein Akkoladenwechsel nach T. 3."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "5",
                             "system": "Klav. o.",
                             "position": "1. Note",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[b]')}} zu e<sup>2</sup> als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: Akkoladenwechsel nach T. 4."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu e<sup>2</sup> als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: Akkoladenwechsel nach T. 4."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "5",
                             "system": "Klav. o.",
                             "position": "2/8",
-                            "comment": "{{ref.getGlyph('[#]')}} zu fis<sup>1</sup>, {{ref.getGlyph('[a]')}} zu c<sup>2</sup> ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu fis<sup>1</sup>, <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu c<sup>2</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "5",
                             "system": "Klav. u.",
                             "position": "2/8",
-                            "comment": "{{ref.getGlyph('[a]')}} zu f/h/d<sup>1</sup> ergänzt."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu f/h/d<sup>1</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -772,7 +772,7 @@
                             "measure": "6",
                             "system": "Klav. o.",
                             "position": "2. Note",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[a]')}} zu d<sup>2</sup> ergänzt."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu d<sup>2</sup> ergänzt."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -786,14 +786,14 @@
                             "measure": "13",
                             "system": "Klav.",
                             "position": "2/8",
-                            "comment": "{{ref.getGlyph('[pp]')}} versetzt von nicht eindeutiger Position zwischen 1–2/8 gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_H'})\"><strong>H</strong></a> und <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_I'})\"><strong>I</strong></a>."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[pp]')}}</span> versetzt von nicht eindeutiger Position zwischen 1–2/8 gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_H'})\"><strong>H</strong></a> und <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_I'})\"><strong>I</strong></a>."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "14",
                             "system": "Klav. o.",
                             "position": "1. Note",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[a]')}} zu g<sup>1</sup> als redundant weggelassen. Unterstimmenschicht: {{ref.getGlyph('[#]')}} zu g als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: Akkoladenwechsel nach T. 13."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu g<sup>1</sup> als redundant weggelassen. Unterstimmenschicht: <span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu g als redundant weggelassen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: Akkoladenwechsel nach T. 13."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -807,7 +807,7 @@
                             "measure": "16",
                             "system": "Klav. o.",
                             "position": "1. Note",
-                            "comment": "Oberstimmenschicht: {{ref.getGlyph('[a]')}} zu g<sup>1</sup> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: kein Akkoladenwechsel nach T. 15."
+                            "comment": "Oberstimmenschicht: <span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu g<sup>1</sup> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: kein Akkoladenwechsel nach T. 15."
                         }
                     ]
                 },
@@ -819,14 +819,14 @@
                             "measure": "3",
                             "system": "Klav. o.",
                             "position": "1/4",
-                            "comment": "{{ref.getGlyph('[#]')}} zu gis ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: kein Akkoladenwechsel nach T. 2."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[#]')}}</span> zu gis ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: kein Akkoladenwechsel nach T. 2."
                         },
                         {
                             "svgGroupId": "TODO",
                             "measure": "3",
                             "system": "Klav. u.",
                             "position": "1/8",
-                            "comment": "{{ref.getGlyph('[b]')}} zu es ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: kein Akkoladenwechsel nach T. 2."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu es ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: kein Akkoladenwechsel nach T. 2."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -924,7 +924,7 @@
                             "measure": "14",
                             "system": "Klav. o.",
                             "position": "1. Note",
-                            "comment": "{{ref.getGlyph('[a]')}} zu h und {{ref.getGlyph('[b]')}} zu b<sup>1</sup> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: kein Akkoladenwechsel nach T. 13."
+                            "comment": "<span class='glyph'>{{ref.getGlyph('[a]')}}</span> zu h und <span class='glyph'>{{ref.getGlyph('[b]')}}</span> zu b<sup>1</sup> ergänzt. <a (click)=\"ref.navigateToReportFragment({complexId: 'op4', fragmentId: 'source_J'})\"><strong>J</strong></a>: kein Akkoladenwechsel nach T. 13."
                         },
                         {
                             "svgGroupId": "TODO",
@@ -938,7 +938,7 @@
                             "measure": "15",
                             "system": "",
                             "position": "Taktanfang",
-                            "comment": "Klammern zu {{ref.getGlyph('[Viertelnote]')}} <em>= 80</em> ergänzt analog T. 1, 10 und 13."
+                            "comment": "Klammern zu <span class='glyph'>{{ref.getGlyph('[Viertelnote]')}}</span> <em>= 80</em> ergänzt analog T. 1, 10 und 13."
                         },
                         {
                             "svgGroupId": "TODO",


### PR DESCRIPTION
This PR adds the spans recently introduced for glyphs in the current PR webern-unibas-ch/awg-app#2053.